### PR TITLE
Pin uvloop to 0.14.0 to fix deploy.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ setup(
         'psycopg2-binary',
         'SQLAlchemy==1.1',
         'swagger-parser',
-        'uvloop',  # Recommended by aiohttp docs
+        'uvloop==0.14.0',  # Recommended by aiohttp docs
         'yarl==0.12.0'
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ setup(
         'jsonschema',
         'mimeparse',
         'PyYaml',
-        'PyJWT',
+        'PyJWT==1.7.1',
         'psycopg2-binary',
         'SQLAlchemy==1.1',
         'swagger-parser',


### PR DESCRIPTION
Higher version requires python >= 3.7